### PR TITLE
[fix] 自動更新が効かなくなる問題の回避

### DIFF
--- a/src/MainPane.tsx
+++ b/src/MainPane.tsx
@@ -84,7 +84,6 @@ export const MainPanel = (
       unlisten = await listen('update_path_list', event => {
         const payload = (event.payload as PaneInfo);
         if (payload.pane_idx !== props.panel_idx) { return; }
-        if (payload.dirctry_path !== dir) { return; }
 
         setFileListInfo(payload.file_list_info);
         setInitFocusFile(payload.init_focus_item);


### PR DESCRIPTION
* パスの最後の区切り文字(\)の有無が揃わなくなるのが原因。
  * 環境によって起きたり起きなかったりで、原因の詳細は不明。